### PR TITLE
feat(rough)!: inline errors

### DIFF
--- a/src/plccng/parse_spec/errors.py
+++ b/src/plccng/parse_spec/errors.py
@@ -168,3 +168,8 @@ class DuplicateAttribute(ValidationError):
             line=rule.line,
             message=f"Duplicate RHS symbol name: '{symbolName}', for rule: '{rule.line.string}', on line: {rule.line.number}. All RHS symbols must have unique names."
         )
+
+
+@dataclass(frozen=True)
+class CircularIncludeError(Exception):
+    line: Line

--- a/src/plccng/parse_spec/parse_rough/parse_lines.py
+++ b/src/plccng/parse_spec/parse_rough/parse_lines.py
@@ -4,6 +4,7 @@ from plccng.parse_spec.structs import Line
 def from_string(string, file=None, startLineNumber=1):
     if string is None:
         return []
+    print(string.splitlines())
     return from_strings(string.splitlines(), file=file, startLineNumber=startLineNumber)
 
 
@@ -14,4 +15,4 @@ def from_file(file, startLineNumber=1):
 
 def from_strings(strings, file=None, startLineNumber=1):
     for i, string in enumerate(strings, start=startLineNumber):
-        yield Line(string=string, file=file, number=i)
+        yield Line(string=string.rstrip(), file=file, number=i)

--- a/src/plccng/parse_spec/parse_rough/parse_rough.py
+++ b/src/plccng/parse_spec/parse_rough/parse_rough.py
@@ -32,3 +32,16 @@ def from_lines_unresolved(lines):
     includes = parse_includes(blocks)
     dividers = parse_dividers(includes)
     return dividers
+
+
+def raise_exceptions(rough):
+    '''
+    Yields each thing from rough.
+    However, if the thing is an Exception,
+    it is raised and iteration halts.
+    '''
+    for thing in rough:
+        if isinstance(thing, Exception):
+            raise thing
+        else:
+            yield thing

--- a/src/plccng/parse_spec/parse_rough/parse_rough_test.py
+++ b/src/plccng/parse_spec/parse_rough/parse_rough_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from . import parse_rough
 from ..structs import Line
 from ..structs import Block
@@ -45,3 +47,18 @@ def test_from_lines():
     assert list(parse_rough.from_lines([Line('%', 1, None)])) == [
         Divider(tool='Java', language='Java', line=Line('%', 1, None))
     ]
+
+
+def test_raise_exceptions():
+    seen = []
+    with pytest.raises(Exception):
+        for thing in parse_rough.raise_exceptions(['one', Exception(), 'two']):
+            seen.append(thing)
+    assert seen == ['one']
+
+
+def test_rases_excptions_no_exception():
+    seen = []
+    for thing in parse_rough.raise_exceptions(['one', 'two']):
+        seen.append(thing)
+    assert seen == ['one', 'two']

--- a/src/plccng/parse_spec/parse_rough/resolve_includes.py
+++ b/src/plccng/parse_spec/parse_rough/resolve_includes.py
@@ -1,9 +1,8 @@
 from pathlib import Path
-
-
+from ..errors import CircularIncludeError
+from ..structs import Include
 from . import parse_rough
 from .parse_includes import parse_includes
-from ..structs import Include
 
 
 def resolve_includes(rough):
@@ -45,12 +44,3 @@ class IncludeResolver():
         rough = parse_rough.from_file_unresolved(file)
         yield from self.resolveIncludes(rough)
         self._files_seen.remove(file)
-
-
-from dataclasses import dataclass
-from ..structs import Line
-
-@dataclass(frozen=True)
-class CircularIncludeError(Exception):
-    line: Line
-

--- a/src/plccng/parse_spec/parse_rough/resolve_includes_test.py
+++ b/src/plccng/parse_spec/parse_rough/resolve_includes_test.py
@@ -1,8 +1,7 @@
-import pytest
+from ..errors import CircularIncludeError
 from ..structs import Line
 from . import parse_rough
-from .parse_includes import parse_includes
-from .resolve_includes import resolve_includes, CircularIncludeError
+from .resolve_includes import resolve_includes
 
 
 def test_None_yields_nothing():


### PR DESCRIPTION
The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.

---

Still thinking about this...

---

Advantages

Instead of raising a CircularIncludeError, we could yield the error instead of a Line. This would allow parse_rough to continue processing after a CircularIncludeError. This makes sense because the contents of the include that is causing the CircularIncludeError has already been loaded. So, processing may be able to continue. So for example, if a file '/f' contains the following...

```
one
%include /f
three
```

In our current implementation, the first line is yielded and then an exception is raised when line 2 is processed.

Under this proposal, the first line is yielded, a CircularIncludeError is yielded, and then the third line is yielded.

---

Disadvantages

The caller is left with the responsibility for detecting errors...

```
for thing in parse_rough.from_file(...):
    if isinstance(thing, Error):
        # ignore it? process it? whatever...
```

But this is true now...

```
try:
    for thing in parse_rough.from_file(...):
        ...
except Error:
    ...
```

The difference is that the caller now has the flexibility to continue processing if there is an error.

The downside is that the "error handling" appears in the main-line processing.

If one needs the original behavior, they could pass the generator to a wrapper function, like so...

```
def raise_excpetions(rough):
    for thing in generator:
        if isinstance(thing, Exceptoin):
            raise thing
        yield thing
```

This has been added to this PR.

---

I think I'm liking this.

---

Would existing code need to change?

Probably. Each client of parse_rough should decide what to do if there is a CircularIncludeError. Theoretically, their current behavior is to raise it as an exception. So they could start there. If they think they could do better, they could move to something else.