### PR TITLE
refactor(spec.rough): add handler param to resolve_includes

### DIFF
--- a/src/plccng/spec/SpecError_test.py
+++ b/src/plccng/spec/SpecError_test.py
@@ -1,6 +1,5 @@
 
 from .lines import Line
-
 from .SpecError import ValidationError2
 
 

--- a/src/plccng/spec/rough/raise_handler.py
+++ b/src/plccng/spec/rough/raise_handler.py
@@ -1,0 +1,2 @@
+def raise_handler(e):
+    raise e

--- a/src/plccng/spec/rough/resolve_includes.py
+++ b/src/plccng/spec/rough/resolve_includes.py
@@ -6,10 +6,11 @@ from .Include import Include
 from .parse_blocks import parse_blocks
 from .parse_dividers import parse_dividers
 from .parse_includes import parse_includes
+from .raise_handler import raise_handler
 
 
-def resolve_includes(rough):
-    return IncludeResolver().resolveIncludes(rough)
+def resolve_includes(rough, handler=raise_handler):
+    return IncludeResolver(handler=handler).resolveIncludes(rough)
 
 
 def from_lines_unresolved(lines):
@@ -25,8 +26,9 @@ def from_file_unresolved(file, startLineNumber=1):
 
 
 class IncludeResolver():
-    def __init__(self):
+    def __init__(self, handler=raise_handler):
         self._files_seen = set()
+        self._handler = handler
 
     def resolveIncludes(self, rough):
         if rough is None:
@@ -42,8 +44,12 @@ class IncludeResolver():
 
     def _resolve_include(self, include):
         file = self._get_absolute_path_to_include_file(include)
-        self._assert_file_has_not_been_included(include, file)
-        yield from self._include_file(file)
+        if file in self._files_seen:
+            self._handler(CircularIncludeError(include.line))
+            # Don't yield anything, and let processing continue to next line.
+        else:
+            self._files_seen.add(file)
+            yield from self._include_file(file)
 
     def _get_absolute_path_to_include_file(self, include):
         p = Path(include.file)
@@ -52,12 +58,7 @@ class IncludeResolver():
         p = str(p)
         return p
 
-    def _assert_file_has_not_been_included(self, include, p):
-        if p in self._files_seen:
-            raise CircularIncludeError(include.line)
-
     def _include_file(self, file):
-        self._files_seen.add(file)
         rough = from_file_unresolved(file)
         yield from self.resolveIncludes(rough)
         self._files_seen.remove(file)

--- a/src/plccng/spec/rough/resolve_includes_test.py
+++ b/src/plccng/spec/rough/resolve_includes_test.py
@@ -39,3 +39,14 @@ def test_relative_path(fs):
     assert result == [
         Line('hi', 1, '/b/c/h')
     ]
+
+
+def test_handler(fs):
+    fs.create_file('/f', contents='%include /f')
+
+    # Handler to ignore errors.
+    def ignore(_):
+        pass
+
+    result = list(resolve_includes(from_string_unresolved('%include /f\nhi'), ignore))
+    assert result[0].string == 'hi'


### PR DESCRIPTION
Currently rough raises exceptions when errors found. Instead we want to hand back a list of errors during processing, and to try to continue processing as much as possible.

But rough is implemented as a composable set of generator returning functions. It doesn't make sense for it to return a list of errors along with a generator, because the error list would always be initially empty;
and the error list would fill as the generator is
expanded. This would be confusing and would likely lead to complicated error prone code in clients.

Instead, we'll add an optional callback parameter
to each parse function. This callback will be called and passed an error object each time an error is detected. Assuming the callback doesn't raise an exception,
processing will continue after the callback returns. This will allow clients to choose how to handle errors.

This commit is the first step along this path.
It adds a `handler` callback parameter to `resolve_includes`. For example, a client can collect errors during processing but allow processing to continue as follows.

```python
errors = []
generator = resolve_includes(..., handler=lambda e: errors.append(e))
````

If a handler is not provided, resolve_includes raises the first error it encounters (the current behavior).


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
