### PR TITLE
refactor(spec.rough): add handler param to parse_blocks

### DIFF
--- a/src/plccng/spec/rough/parse_blocks.py
+++ b/src/plccng/spec/rough/parse_blocks.py
@@ -1,10 +1,12 @@
 import re
 
+from .. import lines
 from .Block import Block
+from .raise_handler import raise_handler
 from .UnclosedBlockError import UnclosedBlockError
 
 
-def parse_blocks(lines):
+def parse_blocks(lines, handler=raise_handler):
     if lines is None:
         return []
     PPP = re.compile(r'^%%%(?:\s*#.*)?$')
@@ -14,12 +16,13 @@ def parse_blocks(lines):
         PPP: PPP,
         PPLC: PPRC
     }
-    return BlockParser(brackets).parse(lines)
+    return BlockParser(brackets, handler).parse(lines)
 
 
 class BlockParser():
-    def __init__(self, brackets):
+    def __init__(self, brackets, handler):
         self.brackets = brackets
+        self.handler = handler
         self.closing = None
 
     def parse(self, lines):
@@ -44,7 +47,12 @@ class BlockParser():
             if self.isClosing(line):
                 yield Block(blockLines)
                 return
-        raise UnclosedBlockError(line)
+        # No closing found.
+        self.handler(UnclosedBlockError(line))
+        # Add a closing line to be consistent (since blocks contain their closing)
+        closing = lines.Line(string='%%%', number=blockLines[-1].number+1, file=blockLines[-1].file)
+        blockLines.append(closing)
+        yield Block(blockLines)
 
     def setClosingFor(self, line):
         for b in self.brackets:

--- a/src/plccng/spec/rough/parse_blocks_test.py
+++ b/src/plccng/spec/rough/parse_blocks_test.py
@@ -27,7 +27,16 @@ def test_unclosed_block_is_an_error():
     assert exception.line == lines.Line('%%%', 1, None)
 
 
-def test_tripple_percent_block():
+def test_handler():
+    def ignore(_):
+        pass
+    OPEN = '%%%'
+    results = list(parse_blocks(lines.parse_from_string(OPEN), handler=ignore))
+    assert results[0].__class__ == Block    # A Block was produced.
+    assert len(results[0].lines) == 2       # A closing line was added.
+
+
+def test_triple_percent_block():
     lines_ = list(lines.parse_from_string('''\
 %%%
 block


### PR DESCRIPTION
The default handler raises an exception (existing behavior).

If a handler is passed, and no closing %%% is found, then parse_blocks produces a Block containing all of the lines from the opening to the end of the file, plus an additional line that parse_blocks creates to represent the closing of the block.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
