### PR TITLE
refactor(spec.rough): add handler param to parse_from_*

### DIFF
--- a/src/plccng/spec/rough/parse_dividers.py
+++ b/src/plccng/spec/rough/parse_dividers.py
@@ -5,17 +5,18 @@ from .Divider import Divider
 
 
 def parse_dividers(lines):
-    return DividerParser(lines).parse()
+    return DividerParser().parse(lines)
 
 
 class DividerParser:
-    def __init__(self, lines):
-        self.lines = lines
+    def __init__(self):
+        self.lines = None
         self.defaultToolPath = "Java"
         self.defaultLanguage = "Java"
         self.patterns = self._compilePatternDictionary()
 
-    def parse(self):
+    def parse(self, lines):
+        self.lines = lines
         if not self.lines:
             return
         for line in self.lines:

--- a/src/plccng/spec/rough/parse_from_lines.py
+++ b/src/plccng/spec/rough/parse_from_lines.py
@@ -1,5 +1,6 @@
+from .raise_handler import raise_handler
 from .resolve_includes import from_lines_unresolved, resolve_includes
 
 
-def parse_from_lines(lines):
-    return resolve_includes(from_lines_unresolved(lines))
+def parse_from_lines(lines, handler=raise_handler):
+    return resolve_includes(from_lines_unresolved(lines, handler=handler), handler=handler)

--- a/src/plccng/spec/rough/parse_from_string.py
+++ b/src/plccng/spec/rough/parse_from_string.py
@@ -1,5 +1,6 @@
+from .raise_handler import raise_handler
 from .resolve_includes import from_string_unresolved, resolve_includes
 
 
-def parse_from_string(string, file=None, startLineNumber=1):
-    return resolve_includes(from_string_unresolved(string, file, startLineNumber))
+def parse_from_string(string, file=None, startLineNumber=1, handler=raise_handler):
+    return resolve_includes(from_string_unresolved(string, file, startLineNumber, handler=handler), handler=handler)

--- a/src/plccng/spec/rough/parse_from_string_test.py
+++ b/src/plccng/spec/rough/parse_from_string_test.py
@@ -4,7 +4,7 @@ from .Divider import Divider
 from .parse_from_string import parse_from_string
 
 
-def test_fromstring():
+def test_parse_from_string():
     assert list(parse_from_string('''\
 one
 %
@@ -34,3 +34,22 @@ four
         Line('%%%', 12, None)
     ])
 ]
+
+
+def test_parse_from_string_with_handler(fs):
+    errors = 0
+    def count(_):
+        nonlocal errors
+        errors += 1
+
+    fs.create_file('/contains_circular_include', contents='%include /contains_circular_include')
+
+    results = list(parse_from_string(handler=count, string='''\
+%include /contains_circular_include
+%%%
+missing
+closing
+'''))
+
+    assert errors == 2
+    assert results[0].__class__ == Block

--- a/src/plccng/spec/rough/resolve_includes.py
+++ b/src/plccng/spec/rough/resolve_includes.py
@@ -13,16 +13,16 @@ def resolve_includes(rough, handler=raise_handler):
     return IncludeResolver(handler=handler).resolveIncludes(rough)
 
 
-def from_lines_unresolved(lines):
-    blocks = parse_blocks(lines)
+def from_lines_unresolved(lines, handler=raise_handler):
+    blocks = parse_blocks(lines, handler=handler)
     includes = parse_includes(blocks)
     dividers = parse_dividers(includes)
     return dividers
 
 
-def from_file_unresolved(file, startLineNumber=1):
+def from_file_unresolved(file, startLineNumber=1, handler=raise_handler):
     lines_ = lines.parse_from_file(file, startLineNumber=startLineNumber)
-    return from_lines_unresolved(lines_)
+    return from_lines_unresolved(lines_, handler=handler)
 
 
 class IncludeResolver():
@@ -59,11 +59,11 @@ class IncludeResolver():
         return p
 
     def _include_file(self, file):
-        rough = from_file_unresolved(file)
+        rough = from_file_unresolved(file, handler=self._handler)
         yield from self.resolveIncludes(rough)
         self._files_seen.remove(file)
 
 
-def from_string_unresolved(string, file=None, startLineNumber=1):
+def from_string_unresolved(string, file=None, startLineNumber=1, handler=raise_handler):
     lines_ = lines.parse_from_string(string, file=file, startLineNumber=startLineNumber)
-    return from_lines_unresolved(lines_)
+    return from_lines_unresolved(lines_, handler=handler)


### PR DESCRIPTION
This completes our refactor to add handler param
to spec.rough. Callers can now pass a `handler` callback to parse_from_* functions. The handler is called
for each error encountered during the processing.
If the handler raises and exception, then processing is halted and the exception is raised. Otherwise
the parser does its best to continue.

```python
from plccng.spec.rough import parse_from_string
results = list(parse_from_string(..., handler=lambda e: print(e)))
```

There are currently two possible errors when parsing the rough. CircularIncludeError and UnclosedBlockError. When a CircularIncludeError is encountered, the handler is called, the Include is skipped, and processing continues. When an UnclosedBlockError is encountered, the handler is called, a closing is created to finish the Block, and processing continues.

In the future, when new errors are added, the creator must decide how processing can continue when that
error is detected.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
