### PR TITLE
fix(ci): skip existing files on TestPyPI to allow workflow retries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
       - name: Smoke test TestPyPI install
         run: |


### PR DESCRIPTION
TestPyPI rejects re-uploading any filename that has been deleted (filename-reuse policy), which makes failed workflow runs unrecoverable without bumping the version. skip-existing: true makes TestPyPI publish tolerant of both already-uploaded and tombstoned filenames.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
