### PR TITLE
fix(ci): skip attestations on TestPyPI to avoid duplicate-attestation…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
+          attestations: false
 
       - name: Smoke test TestPyPI install
         run: |


### PR DESCRIPTION
… error on PyPI

The pypa/gh-action-pypi-publish action generates `.publish.attestation` files alongside the wheel during publish. When the same dist/ is published to two indexes (TestPyPI then PyPI) within one workflow run, the second call sees the leftover attestation files from the first and errors out. Disabling attestations on the TestPyPI step lets the PyPI step generate them fresh — TestPyPI doesn't need attestations anyway.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
