### PR TITLE
feat(scan): stream tokens line by line using Popen

### DIFF
--- a/src/plcc/cmd/scan.py
+++ b/src/plcc/cmd/scan.py
@@ -106,8 +106,13 @@ def main(argv=None):
                     for chunk in sys.stdin.buffer:
                         proc.stdin.write(chunk)
                         proc.stdin.flush()
+            except BrokenPipeError:
+                pass
             finally:
-                proc.stdin.close()
+                try:
+                    proc.stdin.close()
+                except BrokenPipeError:
+                    pass
 
         feed_thread = threading.Thread(target=_feed_input, daemon=True)
         feed_thread.start()
@@ -122,9 +127,8 @@ def main(argv=None):
                 lexeme = record.get("lexeme", "?")
                 source = record.get("source", {})
                 loc = _location_str(source)
-                print(f"{loc} {name} '{lexeme}'")
+                print(f"{loc} {name} '{lexeme}'", flush=True)
 
-        feed_thread.join()
         stderr_thread.join()
         proc.wait()
 

--- a/src/plcc/cmd/scan.py
+++ b/src/plcc/cmd/scan.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import threading
 
 from docopt import docopt, DocoptExit
 
@@ -73,29 +74,47 @@ def main(argv=None):
             print(f"plcc-scan: plcc-spec failed (exit {result.returncode})", file=sys.stderr)
             sys.exit(result.returncode)
 
-        # Build input: concatenate source files/stdin in order
-        input_data = b""
-        for src in sources:
-            if src == '-':
-                input_data += sys.stdin.buffer.read()
-            else:
-                with open(src, "rb") as sf:
-                    input_data += sf.read()
-        if not sources:
-            input_data = sys.stdin.buffer.read()
-
-        # plcc-tokens spec.json < input
-        result = subprocess.run(
+        proc = subprocess.Popen(
             ["plcc-tokens", spec_path, "--continue-on-error"] + child_flags,
-            input=input_data,
+            stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        if result.stderr:
-            events = verbose.parse_child_events(result.stderr.decode("utf-8", errors="replace"))
-            verbose.reformat_child_events(events)
-        for line in result.stdout.decode("utf-8").splitlines():
-            if not line.strip():
+
+        stderr_chunks = []
+
+        def _drain_stderr():
+            stderr_chunks.append(proc.stderr.read())
+
+        stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+        stderr_thread.start()
+
+        def _feed_input():
+            try:
+                if sources:
+                    for src in sources:
+                        if src == '-':
+                            for chunk in sys.stdin.buffer:
+                                proc.stdin.write(chunk)
+                                proc.stdin.flush()
+                        else:
+                            with open(src, "rb") as sf:
+                                for chunk in sf:
+                                    proc.stdin.write(chunk)
+                                    proc.stdin.flush()
+                else:
+                    for chunk in sys.stdin.buffer:
+                        proc.stdin.write(chunk)
+                        proc.stdin.flush()
+            finally:
+                proc.stdin.close()
+
+        feed_thread = threading.Thread(target=_feed_input, daemon=True)
+        feed_thread.start()
+
+        for raw in proc.stdout:
+            line = raw.decode("utf-8").strip()
+            if not line:
                 continue
             record = json.loads(line)
             if record.get("kind") == "token":
@@ -104,6 +123,15 @@ def main(argv=None):
                 source = record.get("source", {})
                 loc = _location_str(source)
                 print(f"{loc} {name} '{lexeme}'")
+
+        feed_thread.join()
+        stderr_thread.join()
+        proc.wait()
+
+        stderr_data = b"".join(stderr_chunks)
+        if stderr_data:
+            events = verbose.parse_child_events(stderr_data.decode("utf-8", errors="replace"))
+            verbose.reformat_child_events(events)
     finally:
         os.unlink(spec_path)
 

--- a/tests/bats/commands/plcc-scan.bats
+++ b/tests/bats/commands/plcc-scan.bats
@@ -69,3 +69,10 @@ setup() {
     [[ "$output" == *"99"* ]]
     [[ "$stderr" == *"error"* ]]
 }
+
+@test "plcc-scan outputs tokens for multi-line input" {
+    run bash -c "printf '42\n99\n' | plcc-scan '${FIXTURES}/trivial.plcc'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"42"* ]]
+    [[ "$output" == *"99"* ]]
+}


### PR DESCRIPTION
Replace subprocess.run with Popen + two background threads so input is fed and output is consumed concurrently, enabling line-by-line streaming instead of buffering all input before starting.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
