### PR TITLE
fix: remove dead TokenOrSkipProperties definition; isolate plcc-scan …

### DIFF
--- a/src/plcc/schemas/token.schema.json
+++ b/src/plcc/schemas/token.schema.json
@@ -23,7 +23,7 @@
         "is_skip":    { "type": "boolean" },
         "winner":     { "type": "boolean" }
       }
-    },
+    }
   },
   "oneOf": [
     {

--- a/src/plcc/schemas/token.schema.json
+++ b/src/plcc/schemas/token.schema.json
@@ -24,17 +24,6 @@
         "winner":     { "type": "boolean" }
       }
     },
-    "TokenOrSkipProperties": {
-      "name":        { "type": "string" },
-      "lexeme":      { "type": "string" },
-      "source":      { "$ref": "#/definitions/SourcePosition" },
-      "regex":       { "type": "string" },
-      "source_line": { "type": "string" },
-      "attempts": {
-        "type": "array",
-        "items": { "$ref": "#/definitions/AttemptEntry" }
-      }
-    }
   },
   "oneOf": [
     {

--- a/tests/bats/commands/plcc-scan.bats
+++ b/tests/bats/commands/plcc-scan.bats
@@ -164,22 +164,17 @@ setup() {
 
 @test "plcc-scan -vv produces no more stderr output than -v" {
     run --separate-stderr bash -c "echo '42' | plcc-scan -v '${FIXTURES}/trivial.plcc'"
-    v1_stderr="$stderr"
+    v1_lines=$(echo "$stderr" | grep '^plcc-scan:' | wc -l)
     run --separate-stderr bash -c "echo '42' | plcc-scan -vv '${FIXTURES}/trivial.plcc'"
-    v2_stderr="$stderr"
-    # -vv should not add scan-specific lines beyond -v
-    v1_lines=$(echo "$v1_stderr" | wc -l)
-    v2_lines=$(echo "$v2_stderr" | wc -l)
+    v2_lines=$(echo "$stderr" | grep '^plcc-scan:' | wc -l)
     [ "$v2_lines" -le "$v1_lines" ]
 }
 
 @test "plcc-scan -vvv produces no more stderr output than -v" {
     run --separate-stderr bash -c "echo '42' | plcc-scan -v '${FIXTURES}/trivial.plcc'"
-    v1_stderr="$stderr"
+    v1_lines=$(echo "$stderr" | grep '^plcc-scan:' | wc -l)
     run --separate-stderr bash -c "echo '42' | plcc-scan -vvv '${FIXTURES}/trivial.plcc'"
-    v3_stderr="$stderr"
-    v1_lines=$(echo "$v1_stderr" | wc -l)
-    v3_lines=$(echo "$v3_stderr" | wc -l)
+    v3_lines=$(echo "$stderr" | grep '^plcc-scan:' | wc -l)
     [ "$v3_lines" -le "$v1_lines" ]
 }
 


### PR DESCRIPTION

TokenOrSkipProperties was defined but never referenced in the schema.

The -vv/-vvv regression tests now grep for ^plcc-scan: before counting lines, isolating scan-emitted events from child-process stderr so the tests remain correct if plcc-spec or plcc-tokens add output at higher verbosity levels in future.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
