### PR TITLE
fix(rep): handle non-dict JSON values from interpreter

### DIFF
--- a/src/plcc/cmd/rep.py
+++ b/src/plcc/cmd/rep.py
@@ -184,7 +184,7 @@ def _read_response(stdout, verbose_format):
         except json.JSONDecodeError:
             print(line)
             continue
-        if 'kind' not in record:
+        if not isinstance(record, dict) or 'kind' not in record:
             print(line)
             continue
         _render_record(record, verbose_format)

--- a/src/plcc/cmd/rep_test.py
+++ b/src/plcc/cmd/rep_test.py
@@ -99,3 +99,29 @@ def test_feed_accepts_eof_kwarg(monkeypatch, handler):
     procs = iter([_proc(), _proc(stdout=b"")])
     monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: next(procs))
     assert h.feed(b"\n", "-", eof=True) is False
+
+
+def test_feed_handles_non_dict_json_number_from_interpreter(monkeypatch, handler, capsys):
+    # Interpreter emits a bare JSON number then a proper result record.
+    response = b'42\n{"kind":"result","value":"ok"}\n'
+    h, _ = handler
+    h._interpreter.stdout = io.BytesIO(response)
+    procs = iter([_proc(), _proc(stdout=_tree())])
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: next(procs))
+    h.feed(b"1\n", "-")
+    out, _ = capsys.readouterr()
+    assert "42" in out
+    assert "ok" in out
+
+
+def test_feed_handles_non_dict_json_array_from_interpreter(monkeypatch, handler, capsys):
+    # Interpreter emits a JSON array then a proper result record.
+    response = b'[1,2,3]\n{"kind":"result","value":"done"}\n'
+    h, _ = handler
+    h._interpreter.stdout = io.BytesIO(response)
+    procs = iter([_proc(), _proc(stdout=_tree())])
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: next(procs))
+    h.feed(b"1\n", "-")
+    out, _ = capsys.readouterr()
+    assert "[1, 2, 3]" in out or "[1,2,3]" in out
+    assert "done" in out


### PR DESCRIPTION
Bare JSON numbers (and other non-dict values) caused a TypeError because 'in' requires an iterable. Guard with isinstance(record, dict) before checking for the 'kind' key.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
