### PR TITLE
fix(lang): exit 130 cleanly on ^C in plcc-lang-run, plcc-java-run, pl…

### DIFF
--- a/src/plcc/lang/ext/java/run.py
+++ b/src/plcc/lang/ext/java/run.py
@@ -40,11 +40,14 @@ def main(argv=None):
         sys.exit(1)
     json_jar = str(json_jars[0])
     classpath = f"{output_dir}{os.pathsep}{json_jar}"
-    result = subprocess.run(
-        ['java', '-cp', classpath, 'Main'],
-        stdin=sys.stdin,
-        stdout=sys.stdout,
-        stderr=sys.stderr,
-    )
+    try:
+        result = subprocess.run(
+            ['java', '-cp', classpath, 'Main'],
+            stdin=sys.stdin,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+    except KeyboardInterrupt:
+        sys.exit(130)
     verbose.emit(Events.FINISHED, message=f'exit {result.returncode}')
     sys.exit(result.returncode)

--- a/src/plcc/lang/ext/java/run_test.py
+++ b/src/plcc/lang/ext/java/run_test.py
@@ -1,5 +1,4 @@
 import subprocess
-from pathlib import Path
 
 import pytest
 

--- a/src/plcc/lang/ext/java/run_test.py
+++ b/src/plcc/lang/ext/java/run_test.py
@@ -1,0 +1,23 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from .run import main as run_main
+
+
+def test_keyboard_interrupt_in_subprocess_exits_130(monkeypatch, tmp_path):
+    (tmp_path / "runtime").mkdir()
+    (tmp_path / "runtime" / "org.json-1.0.jar").touch()
+
+    def raise_ki(*a, **kw):
+        raise KeyboardInterrupt()
+    monkeypatch.setattr(subprocess, "run", raise_ki)
+    exit_code = None
+    try:
+        run_main([f"--output={tmp_path}"])
+    except SystemExit as e:
+        exit_code = e.code
+    except KeyboardInterrupt:
+        pytest.fail("KeyboardInterrupt escaped — should be converted to sys.exit(130)")
+    assert exit_code == 130

--- a/src/plcc/lang/ext/python/run.py
+++ b/src/plcc/lang/ext/python/run.py
@@ -34,11 +34,14 @@ def main(argv=None):
     output_dir = args['--output']
     main_py = os.path.join(output_dir, 'main.py')
     verbose.emit(Events.STARTED, message=f'running {main_py}')
-    result = subprocess.run(
-        [sys.executable, '-u', main_py],
-        stdin=sys.stdin,
-        stdout=sys.stdout,
-        stderr=sys.stderr,
-    )
+    try:
+        result = subprocess.run(
+            [sys.executable, '-u', main_py],
+            stdin=sys.stdin,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+    except KeyboardInterrupt:
+        sys.exit(130)
     verbose.emit(Events.FINISHED, message=f'exit {result.returncode}')
     sys.exit(result.returncode)

--- a/src/plcc/lang/ext/python/run_test.py
+++ b/src/plcc/lang/ext/python/run_test.py
@@ -1,0 +1,19 @@
+import subprocess
+
+import pytest
+
+from .run import main as run_main
+
+
+def test_keyboard_interrupt_in_subprocess_exits_130(monkeypatch, tmp_path):
+    def raise_ki(*a, **kw):
+        raise KeyboardInterrupt()
+    monkeypatch.setattr(subprocess, "run", raise_ki)
+    exit_code = None
+    try:
+        run_main([f"--output={tmp_path}"])
+    except SystemExit as e:
+        exit_code = e.code
+    except KeyboardInterrupt:
+        pytest.fail("KeyboardInterrupt escaped — should be converted to sys.exit(130)")
+    assert exit_code == 130

--- a/src/plcc/lang/run.py
+++ b/src/plcc/lang/run.py
@@ -40,6 +40,9 @@ def main(argv=None):
         sys.exit(0)
     verbose.emit(Events.STARTED, message=f"dispatching to {cmd}")
     child_cmd = [cmd, f"--output={output}"] + verbose.child_flags()
-    result = subprocess.run(child_cmd, stdin=sys.stdin)
+    try:
+        result = subprocess.run(child_cmd, stdin=sys.stdin)
+    except KeyboardInterrupt:
+        sys.exit(130)
     verbose.emit(Events.FINISHED, message=f"exit {result.returncode}")
     sys.exit(result.returncode)

--- a/src/plcc/lang/run_test.py
+++ b/src/plcc/lang/run_test.py
@@ -1,0 +1,21 @@
+import subprocess
+import shutil
+
+import pytest
+
+from .run import main as run_main
+
+
+def test_keyboard_interrupt_in_subprocess_exits_130(monkeypatch):
+    def raise_ki(*a, **kw):
+        raise KeyboardInterrupt()
+    monkeypatch.setattr(subprocess, "run", raise_ki)
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    exit_code = None
+    try:
+        run_main(["--target=Java", "--output=build/java"])
+    except SystemExit as e:
+        exit_code = e.code
+    except KeyboardInterrupt:
+        pytest.fail("KeyboardInterrupt escaped — should be converted to sys.exit(130)")
+    assert exit_code == 130


### PR DESCRIPTION
…cc-python-run


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
