### PR TITLE
fix(source-runner): use read1() in EOF mode so one ^D submits typed c…

### DIFF
--- a/src/plcc/cmd/source_runner.py
+++ b/src/plcc/cmd/source_runner.py
@@ -60,6 +60,8 @@ class SourceRunner:
     def _read_line(self, prompt):
         try:
             print(prompt, end="", flush=True, file=sys.stderr)
+            if self._submit_on == SubmitOn.EOF:
+                return sys.stdin.buffer.read1(4096)
             return sys.stdin.buffer.readline()
         except KeyboardInterrupt:
             return None

--- a/src/plcc/cmd/source_runner.py
+++ b/src/plcc/cmd/source_runner.py
@@ -61,7 +61,7 @@ class SourceRunner:
         try:
             print(prompt, end="", flush=True, file=sys.stderr)
             if self._submit_on == SubmitOn.EOF:
-                return sys.stdin.buffer.read1(4096)
+                return sys.stdin.buffer.read1(65536)
             return sys.stdin.buffer.readline()
         except KeyboardInterrupt:
             return None

--- a/src/plcc/cmd/source_runner_test.py
+++ b/src/plcc/cmd/source_runner_test.py
@@ -89,6 +89,20 @@ def _tty_stdin(lines):
     return SimpleNamespace(isatty=lambda: True, buffer=buf)
 
 
+def _read1_tty(reads):
+    """Fake TTY stdin where each read1() call returns the next item from reads."""
+    it = iter(reads)
+
+    class _Buf:
+        def read1(self, n):
+            return next(it, b"")
+
+        def readline(self):
+            raise AssertionError("readline() called in EOF mode")
+
+    return SimpleNamespace(isatty=lambda: True, buffer=_Buf())
+
+
 def test_interactive_prints_hint(monkeypatch, runner, capsys):
     monkeypatch.setattr(sys, "stdin", _tty_stdin([b"hello\n", b""]))
     runner.run(["-"], RecordingHandler())
@@ -504,5 +518,19 @@ def test_eof_mode_enter_then_ctrl_d_submits(monkeypatch):
     _eof_runner().run(["-"], handler)
     assert len(handler.calls) == 1
     assert handler.calls[0][0] == b"hello\n"
+
+
+def test_eof_mode_ctrl_d_without_enter_submits_immediately(monkeypatch):
+    # In EOF mode, typing content then pressing ^D (no Enter) must submit on the
+    # FIRST ^D. In Unix canonical mode, ^D flushes typed bytes to the read buffer
+    # without a newline. readline() would block waiting for \n or a second ^D;
+    # read1() returns immediately with the flushed bytes.
+    # Simulate: read1() returns b"42" (typed then ^D), then b"" (exit).
+    buf = _read1_tty([b"42", b""])
+    monkeypatch.setattr(sys, "stdin", buf)
+    handler = RecordingHandler(results=[True])
+    _eof_runner().run(["-"], handler)
+    assert len(handler.calls) == 1
+    assert handler.calls[0][0] == b"42"
 
 

--- a/src/plcc/cmd/source_runner_test.py
+++ b/src/plcc/cmd/source_runner_test.py
@@ -90,12 +90,26 @@ def _tty_stdin(lines):
 
 
 def _read1_tty(reads):
-    """Fake TTY stdin where each read1() call returns the next item from reads."""
-    it = iter(reads)
+    """Fake TTY stdin that honors the n argument of read1().
+
+    Non-empty entries in `reads` are concatenated into a single buffer;
+    a b'' entry marks the end of input (subsequent read1() calls return b'').
+    Each read1(n) call returns at most n bytes, allowing tests to exercise
+    the boundary behavior of large reads.
+    """
+    data = b"".join(r for r in reads if r)
+    view = memoryview(data)
+    pos = [0]
+    eof = len(data)
 
     class _Buf:
         def read1(self, n):
-            return next(it, b"")
+            start = pos[0]
+            if start >= eof:
+                return b""
+            end = min(start + n, eof)
+            pos[0] = end
+            return bytes(view[start:end])
 
         def readline(self):
             raise AssertionError("readline() called in EOF mode")
@@ -532,5 +546,20 @@ def test_eof_mode_ctrl_d_without_enter_submits_immediately(monkeypatch):
     _eof_runner().run(["-"], handler)
     assert len(handler.calls) == 1
     assert handler.calls[0][0] == b"42"
+
+
+def test_eof_mode_long_line_not_misclassified_as_partial_eof(monkeypatch):
+    # A line longer than 4096 bytes must not be force-submitted as partial EOF.
+    # Linux's MAX_CANON = 4096: read1(4096) would return the first 4096 bytes
+    # without the trailing \n, which _is_partial_eof() would misidentify as ^D.
+    # read1(65536) fits any canonical line in one call, so only a genuine ^D
+    # (no \n) triggers the partial-EOF path.
+    long_line = b"x" * 5000 + b"\n"
+    buf = _read1_tty([long_line, b""])
+    monkeypatch.setattr(sys, "stdin", buf)
+    handler = RecordingHandler(results=[True])
+    _eof_runner().run(["-"], handler)
+    assert len(handler.calls) == 1
+    assert handler.calls[0][0] == long_line
 
 


### PR DESCRIPTION
…ontent

In Unix canonical mode, ^D flushes typed bytes to the OS read buffer without a newline. readline() sees a partial read and blocks, waiting for \n or a zero-length read (second ^D). read1() makes at most one OS read call and returns immediately with whatever is available, so the first ^D submits as expected.

Also removes two incorrect tests added during earlier mis-diagnosis and adds a correct failing test (using a read1-based mock) that the fix makes pass.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
