### PR TITLE
fix(diagram): replace Python mmdc wrapper with npm mmdc CLI subprocess

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:6b2d306f6948d58d70f74429f9d1c50cbfd1e86854690756e3716542bb483184"
+content_hash = "sha256:04745fcb9d4f1f21dc5181022efcfb02c38347bb8262b410940e990be27d1894"
 
 [[metadata.targets]]
 requires_python = "~=3.12"
@@ -806,19 +806,6 @@ files = [
 ]
 
 [[package]]
-name = "mmdc"
-version = "0.4.1"
-requires_python = ">=3.4"
-summary = "Python-native Mermaid diagram converter – no browser, Node.js, or npm required. Renders diagrams to SVG using PhantomJS via phasma, perfect for documentation automation and CI/CD pipelines."
-groups = ["dev"]
-dependencies = [
-    "phasma>=0.4.0",
-]
-files = [
-    {file = "mmdc-0.4.1-py3-none-any.whl", hash = "sha256:84bccd4ab7a473c40511043c243242ca88fbad806351f8161765589117afbbd3"},
-]
-
-[[package]]
 name = "more-itertools"
 version = "11.0.2"
 requires_python = ">=3.10"
@@ -875,19 +862,6 @@ groups = ["dev"]
 files = [
     {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
     {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
-]
-
-[[package]]
-name = "phasma"
-version = "0.5.0"
-requires_python = ">=3.4"
-summary = "A modern PhantomJS driver for Python with bundled binaries, providing headless browser automation, web page rendering, and JavaScript execution."
-groups = ["dev"]
-files = [
-    {file = "phasma-0.5.0-py3-none-macosx_10_9_universal2.whl", hash = "sha256:d209e9c2720fbc9ea1e07bd0ae67d1b90075a88886a7438121a084d07bda56c7"},
-    {file = "phasma-0.5.0-py3-none-manylinux_2_17_i686.whl", hash = "sha256:cd3772db3bc52ac8478fc23b82ea7636c1889b76f2394ceb03bdc1efac01e348"},
-    {file = "phasma-0.5.0-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:768365d8035f48f574b6496924aaa33ee8b52d2862ccfae8255d7e37d4ceb340"},
-    {file = "phasma-0.5.0-py3-none-win_amd64.whl", hash = "sha256:99dc29b11d55b9574772c5a7c0feb407704e8e20f2f534791c3c125a5dda4cd9"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,6 @@ classifiers = [
     "Topic :: Education",
 ]
 
-[project.optional-dependencies]
-diagram = ["mmdc"]
 
 [project.urls]
 Homepage = "https://github.com/ourPLCC/plcc-ng"
@@ -94,7 +92,6 @@ dev = [
     "check-jsonschema>=0.29.0",
     "python-semantic-release>=9.0.0",
     "twine>=5.0.0",
-    "mmdc>=0.4.1",
 ]
 
 [tool.semantic_release]

--- a/src/plcc/diagram/mermaid/build.py
+++ b/src/plcc/diagram/mermaid/build.py
@@ -1,4 +1,6 @@
 import enum
+import shutil
+import subprocess
 import sys
 
 from docopt import docopt
@@ -31,23 +33,19 @@ def main(argv=None):
     input_file = args['--input']
     output_file = args['--output']
     verbose.emit(Events.STARTED, message=f"rendering {input_file}")
-    try:
-        from mmdc import MermaidConverter
-    except ImportError:
+    if not shutil.which('mmdc'):
         print(
-            "plcc-mermaid-diagram-build: mmdc not installed — "
-            "run: pip install plcc[diagram]",
+            "plcc-mermaid-diagram-build: mmdc not found — "
+            "run: npm install -g @mermaid-js/mermaid-cli",
             file=sys.stderr,
         )
         sys.exit(1)
-    with open(input_file) as f:
-        source = f.read()
-    converter = MermaidConverter()
-    try:
-        png_bytes = converter.to_png(source)
-    except RuntimeError as e:
-        print(f"plcc-mermaid-diagram-build: {e}", file=sys.stderr)
-        sys.exit(1)
-    with open(output_file, 'wb') as f:
-        f.write(png_bytes)
+    result = subprocess.run(
+        ['mmdc', '-i', input_file, '-o', output_file],
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.decode('utf-8', errors='replace').strip()
+        print(f"plcc-mermaid-diagram-build: mmdc failed: {stderr}", file=sys.stderr)
+        sys.exit(result.returncode)
     verbose.emit(Events.FINISHED, message=f"wrote {output_file}")

--- a/src/plcc/diagram/mermaid/build_test.py
+++ b/src/plcc/diagram/mermaid/build_test.py
@@ -1,6 +1,6 @@
 import subprocess
 import pytest
-from unittest.mock import patch, call
+from unittest.mock import patch
 
 from .build import main as run_main
 

--- a/src/plcc/diagram/mermaid/build_test.py
+++ b/src/plcc/diagram/mermaid/build_test.py
@@ -1,5 +1,6 @@
+import subprocess
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, call
 
 from .build import main as run_main
 
@@ -10,32 +11,49 @@ def test_missing_required_args_exits_nonzero():
         run_main([])
 
 
-def test_missing_mmdc_prints_helpful_error(tmp_path, capsys):
+def test_missing_mmdc_cli_prints_helpful_error(tmp_path, capsys):
     src = tmp_path / "diagram.mmd"
     src.write_text("classDiagram\n")
     out = tmp_path / "diagram.png"
 
-    with patch.dict('sys.modules', {'mmdc': None}):
+    with patch('shutil.which', return_value=None):
         with pytest.raises(SystemExit) as exc:
             run_main([f'--input={src}', f'--output={out}'])
 
     assert exc.value.code != 0
     _, err = capsys.readouterr()
-    assert 'pip install plcc[diagram]' in err
+    assert 'npm install -g @mermaid-js/mermaid-cli' in err
 
 
-def test_calls_mmdc_converter(tmp_path):
+def test_calls_mmdc_with_correct_args(tmp_path):
     src = tmp_path / "diagram.mmd"
     src.write_text("classDiagram\n    class Foo {}\n")
     out = tmp_path / "diagram.png"
 
-    mock_converter = MagicMock()
-    mock_converter.to_png.return_value = b'\x89PNG\r\n'
-    mock_mmdc = MagicMock()
-    mock_mmdc.MermaidConverter.return_value = mock_converter
+    with patch('shutil.which', return_value='/usr/bin/mmdc'):
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0)
+            run_main([f'--input={src}', f'--output={out}'])
 
-    with patch.dict('sys.modules', {'mmdc': mock_mmdc}):
-        run_main([f'--input={src}', f'--output={out}'])
+    mock_run.assert_called_once_with(
+        ['mmdc', '-i', str(src), '-o', str(out)],
+        stderr=subprocess.PIPE,
+    )
 
-    mock_converter.to_png.assert_called_once_with("classDiagram\n    class Foo {}\n")
-    assert out.read_bytes() == b'\x89PNG\r\n'
+
+def test_mmdc_nonzero_exit_prints_error_and_exits(tmp_path, capsys):
+    src = tmp_path / "diagram.mmd"
+    src.write_text("classDiagram\n")
+    out = tmp_path / "diagram.png"
+
+    with patch('shutil.which', return_value='/usr/bin/mmdc'):
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                [], 1, stderr=b'mmdc: error rendering diagram\n'
+            )
+            with pytest.raises(SystemExit) as exc:
+                run_main([f'--input={src}', f'--output={out}'])
+
+    assert exc.value.code != 0
+    _, err = capsys.readouterr()
+    assert 'mmdc' in err


### PR DESCRIPTION
The Python mmdc package required PhantomJS (EOL) and wasn't reliably available on PyPI. Switch plcc-mermaid-diagram-build to shell out to the mmdc npm CLI (@mermaid-js/mermaid-cli) instead. Error message now points to the correct install command.

Also removes mmdc from pyproject.toml optional-dependencies and dev deps.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
