### PR TITLE
fix(diagram): replace plantuml PyPI dep with stdlib implementation

### DIFF
--- a/docs/issues/041-diagram-build-not-during-make-all.md
+++ b/docs/issues/041-diagram-build-not-during-make-all.md
@@ -1,0 +1,25 @@
+# 041 - plcc-diagram-build should not run during make-all
+
+**Type:** fix
+**Date:** 2026-05-25
+
+## Description
+
+`plcc-make` (make-all) currently runs `plcc-diagram-build`, which makes an outbound HTTP request to plantuml.com. This causes make-all to fail or hang whenever the network is unavailable, and creates unnecessary latency on every build.
+
+Build steps should produce artifacts that can be inspected offline. Diagram rendering — which requires a network call — belongs only in the viewing flow (`plcc-diagram`), not in the build flow.
+
+**Desired behavior:**
+
+- `plcc-make` / make-all: runs `plcc-diagram-emit` to produce the `.puml` source file, but does **not** run `plcc-diagram-build` (no HTTP call, no PNG).
+- `plcc-diagram` (the viewer command): runs `plcc-diagram-build` to render the `.puml` to PNG and then displays it.
+
+## Steps to Reproduce
+
+1. Disconnect from the network.
+2. Run `plcc-diagram` on a grammar file that uses the plantuml format.
+3. Observe that make-all fails or hangs waiting for plantuml.com.
+
+## Notes
+
+`plcc-diagram-emit` is already a separate command and produces the `.puml` file on its own. The build pipeline only needs to emit; the render step can be deferred to when the user actually asks to view the diagram.

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:5d75c53c58c7f5efa983bfc9e7823c5acc66d826f88836d324fb197bd918112f"
+content_hash = "sha256:5711f8e0bcc3732403a3ee001e30e904004adb0ccb62487ef828e9396c3acded"
 
 [[metadata.targets]]
 requires_python = "~=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ plcc-java-build = "plcc.lang.ext.java.build:main"
 plcc-java-run   = "plcc.lang.ext.java.run:main"
 
 [project.optional-dependencies]
-diagram = ["plantuml"]
+diagram = []
 
 [tool.pdm.scripts]
 test = "pytest -qq -rfEsxXP --cov=plcc --cov-branch --cov-report term-missing:skip-covered"

--- a/src/plcc/diagram/plantuml/build.py
+++ b/src/plcc/diagram/plantuml/build.py
@@ -36,7 +36,7 @@ _B64_TO_PLANTUML = bytes.maketrans(
 
 def _encode(source):
     compressed = zlib.compress(source.encode('utf-8'))
-    return base64.b64encode(compressed[2:-4]).translate(_B64_TO_PLANTUML).decode('utf-8')
+    return base64.b64encode(compressed[2:-4]).rstrip(b'=').translate(_B64_TO_PLANTUML).decode('utf-8')
 
 
 def main(argv=None):

--- a/src/plcc/diagram/plantuml/build.py
+++ b/src/plcc/diagram/plantuml/build.py
@@ -1,5 +1,8 @@
+import base64
 import enum
 import sys
+import urllib.request
+import zlib
 
 from docopt import docopt
 
@@ -23,6 +26,19 @@ class Events(enum.Enum):
     FINISHED = "finished"
 
 
+_PLANTUML_ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_'
+_BASE64_ALPHABET   = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+_B64_TO_PLANTUML = bytes.maketrans(
+    _BASE64_ALPHABET.encode('utf-8'),
+    _PLANTUML_ALPHABET.encode('utf-8'),
+)
+
+
+def _encode(source):
+    compressed = zlib.compress(source.encode('utf-8'))
+    return base64.b64encode(compressed[2:-4]).translate(_B64_TO_PLANTUML).decode('utf-8')
+
+
 def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
@@ -32,22 +48,11 @@ def main(argv=None):
     output_file = args['--output']
     verbose.emit(Events.STARTED, message=f"rendering {input_file}")
     try:
-        import plantuml as plantuml_lib
-    except ImportError:
-        print(
-            "plcc-plantuml-diagram-build: plantuml not installed — "
-            "run: pip install plcc-ng[diagram]",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    try:
-        server = plantuml_lib.PlantUML(
-            url='https://www.plantuml.com/plantuml/png/',
-            request_opts={'timeout': 30},
-        )
         with open(input_file) as f:
             source = f.read()
-        png_bytes = server.processes(source)
+        url = f'https://www.plantuml.com/plantuml/png/{_encode(source)}'
+        with urllib.request.urlopen(url, timeout=30) as response:
+            png_bytes = response.read()
     except Exception as e:
         print(f"plcc-plantuml-diagram-build: {e}", file=sys.stderr)
         sys.exit(1)

--- a/src/plcc/diagram/plantuml/build_test.py
+++ b/src/plcc/diagram/plantuml/build_test.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from .build import main as run_main
+from .build import main as run_main, _encode
 
 
 def test_missing_required_args_exits_nonzero():
@@ -10,18 +10,10 @@ def test_missing_required_args_exits_nonzero():
         run_main([])
 
 
-def test_missing_plantuml_lib_prints_helpful_error(tmp_path, capsys):
-    src = tmp_path / "diagram.puml"
-    src.write_text("@startuml\n@enduml\n")
-    out = tmp_path / "diagram.png"
-
-    with patch.dict('sys.modules', {'plantuml': None}):
-        with pytest.raises(SystemExit) as exc:
-            run_main([f'--input={src}', f'--output={out}'])
-
-    assert exc.value.code != 0
-    _, err = capsys.readouterr()
-    assert 'pip install plcc-ng[diagram]' in err
+def test_encode_returns_nonempty_string():
+    result = _encode("@startuml\n@enduml\n")
+    assert isinstance(result, str)
+    assert len(result) > 0
 
 
 def test_calls_plantuml_server_and_writes_png(tmp_path):
@@ -30,54 +22,39 @@ def test_calls_plantuml_server_and_writes_png(tmp_path):
     out = tmp_path / "diagram.png"
     fake_png = b'\x89PNG fake'
 
-    mock_lib = MagicMock()
-    mock_server = MagicMock()
-    mock_server.processes.return_value = fake_png
-    mock_lib.PlantUML.return_value = mock_server
+    mock_response = MagicMock()
+    mock_response.__enter__.return_value.read.return_value = fake_png
 
-    with patch.dict('sys.modules', {'plantuml': mock_lib}):
+    with patch('urllib.request.urlopen', return_value=mock_response) as mock_urlopen:
         run_main([f'--input={src}', f'--output={out}'])
 
     assert out.read_bytes() == fake_png
-    mock_lib.PlantUML.assert_called_once_with(
-        url='https://www.plantuml.com/plantuml/png/',
-        request_opts={'timeout': 30},
-    )
-    mock_server.processes.assert_called_once_with("@startuml\nclass Foo {}\n@enduml\n")
+    url_called, = mock_urlopen.call_args.args
+    assert url_called.startswith('https://www.plantuml.com/plantuml/png/')
+    assert mock_urlopen.call_args.kwargs == {'timeout': 30}
 
 
 def test_missing_input_file_exits_with_error(tmp_path, capsys):
     src = tmp_path / "nonexistent.puml"
     out = tmp_path / "diagram.png"
 
-    mock_lib = MagicMock()
-    mock_lib.PlantUML.return_value = MagicMock()
-
-    with patch.dict('sys.modules', {'plantuml': mock_lib}):
-        with pytest.raises(SystemExit) as exc:
-            run_main([f'--input={src}', f'--output={out}'])
+    with pytest.raises(SystemExit) as exc:
+        run_main([f'--input={src}', f'--output={out}'])
 
     assert exc.value.code != 0
     _, err = capsys.readouterr()
     assert err.strip() != ''
 
 
-def test_plantuml_error_prints_message_and_exits(tmp_path, capsys):
+def test_server_error_prints_message_and_exits(tmp_path, capsys):
     src = tmp_path / "diagram.puml"
     src.write_text("@startuml\n@enduml\n")
     out = tmp_path / "diagram.png"
 
-    mock_lib = MagicMock()
-    mock_server = MagicMock()
-    mock_server.processes.side_effect = Exception("connection refused")
-    mock_lib.PlantUML.return_value = mock_server
-
-    with patch.dict('sys.modules', {'plantuml': mock_lib}):
+    with patch('urllib.request.urlopen', side_effect=Exception("connection refused")):
         with pytest.raises(SystemExit) as exc:
             run_main([f'--input={src}', f'--output={out}'])
 
     assert exc.value.code != 0
     _, err = capsys.readouterr()
     assert 'connection refused' in err
-
-

--- a/src/plcc/diagram/plantuml/build_test.py
+++ b/src/plcc/diagram/plantuml/build_test.py
@@ -10,10 +10,20 @@ def test_missing_required_args_exits_nonzero():
         run_main([])
 
 
-def test_encode_returns_nonempty_string():
-    result = _encode("@startuml\n@enduml\n")
-    assert isinstance(result, str)
-    assert len(result) > 0
+_PLANTUML_ALPHABET = set('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_')
+
+
+def test_encode_known_good():
+    assert _encode("@startuml\nclass Foo {}\n@enduml\n") == 'SoWkIImgAStDuKhEIImkLd3BprUehkLoICrB0Ga200'
+
+
+def test_encode_no_padding():
+    assert '=' not in _encode("@startuml\n@enduml\n")
+
+
+def test_encode_only_plantuml_alphabet():
+    result = _encode("@startuml\nclass Foo {}\n@enduml\n")
+    assert all(c in _PLANTUML_ALPHABET for c in result)
 
 
 def test_calls_plantuml_server_and_writes_png(tmp_path):


### PR DESCRIPTION
plantuml 0.3.0 imports `six` which is not declared as a dependency, causing `import plantuml` to fail with ModuleNotFoundError in any fresh install. Replace with a stdlib-only implementation (zlib, base64, urllib.request) that encodes PlantUML source and calls plantuml.com directly, removing the need for any optional dependency.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
