### PR TITLE
fix(diagram): add User-Agent header to plantuml.com requests

### DIFF
--- a/src/plcc/diagram/plantuml/build.py
+++ b/src/plcc/diagram/plantuml/build.py
@@ -51,7 +51,8 @@ def main(argv=None):
         with open(input_file) as f:
             source = f.read()
         url = f'https://www.plantuml.com/plantuml/png/{_encode(source)}'
-        with urllib.request.urlopen(url, timeout=30) as response:
+        req = urllib.request.Request(url, headers={'User-Agent': 'plcc-ng/1.0'})
+        with urllib.request.urlopen(req, timeout=30) as response:
             png_bytes = response.read()
     except Exception as e:
         print(f"plcc-plantuml-diagram-build: {e}", file=sys.stderr)

--- a/src/plcc/diagram/plantuml/build_test.py
+++ b/src/plcc/diagram/plantuml/build_test.py
@@ -39,8 +39,9 @@ def test_calls_plantuml_server_and_writes_png(tmp_path):
         run_main([f'--input={src}', f'--output={out}'])
 
     assert out.read_bytes() == fake_png
-    url_called, = mock_urlopen.call_args.args
-    assert url_called.startswith('https://www.plantuml.com/plantuml/png/')
+    req_called, = mock_urlopen.call_args.args
+    assert req_called.full_url.startswith('https://www.plantuml.com/plantuml/png/')
+    assert req_called.get_header('User-agent') == 'plcc-ng/1.0'
     assert mock_urlopen.call_args.kwargs == {'timeout': 30}
 
 


### PR DESCRIPTION
Cloudflare Bot Fight Mode on plantuml.com returns 403 (error 1010) when requests carry no User-Agent. Python's urllib sends none by default. Set User-Agent: plcc-ng/1.0 on every request.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
