### PR TITLE
fix(verbose): preserve indentation and blank lines in plain-text stde…

### DIFF
--- a/src/plcc/verbose.py
+++ b/src/plcc/verbose.py
@@ -84,11 +84,12 @@ class VerboseContext:
     def parse_child_events(self, stderr_text):
         events = []
         for line in stderr_text.splitlines():
-            line = line.strip()
-            if not line:
+            stripped = line.strip()
+            if not stripped:
+                print(file=sys.stderr, flush=True)
                 continue
             try:
-                events.append(json.loads(line))
+                events.append(json.loads(stripped))
             except json.JSONDecodeError:
                 print(line, file=sys.stderr, flush=True)
         return events

--- a/src/plcc/verbose_test.py
+++ b/src/plcc/verbose_test.py
@@ -83,6 +83,22 @@ def test_child_flags_for_orchestrator_keeps_higher_user_level():
     assert flags.count("-v") == 3
 
 
+def test_parse_child_events_preserves_indentation_of_plain_text(capsys):
+    args = {"-v": 0, "--verbose-format": "text"}
+    ctx = VerboseContext.from_args("plcc-test", SampleEvents, args)
+    ctx.parse_child_events("  indented line\n")
+    captured = capsys.readouterr()
+    assert "  indented line" in captured.err
+
+
+def test_parse_child_events_preserves_blank_lines(capsys):
+    args = {"-v": 0, "--verbose-format": "text"}
+    ctx = VerboseContext.from_args("plcc-test", SampleEvents, args)
+    ctx.parse_child_events("first line\n\nsecond line\n")
+    captured = capsys.readouterr()
+    assert "first line\n\nsecond line" in captured.err
+
+
 def test_parse_child_events_roundtrip(capsys):
     args = {"-v": 1, "--verbose-format": "json"}
     ctx = VerboseContext.from_args("plcc-test", SampleEvents, args)


### PR DESCRIPTION
…rr passthrough

parse_child_events stripped leading whitespace and dropped blank lines before forwarding non-JSON stderr lines. This broke LL(1) conflict message formatting when plcc-parse or plcc-rep captured plcc-make's stderr and re-emitted it.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
