### PR TITLE
fix(ci): fix dev docs deployment to gh-pages subdirectory

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,9 +60,12 @@ jobs:
         run: pip install pdm
       - name: Install dependencies
         run: pdm install
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Build developer docs
+        run: pdm run mkdocs build --config-file mkdocs-dev.yml
       - name: Deploy developer docs
-        run: pdm run mkdocs gh-deploy --config-file mkdocs-dev.yml --dest-dir dev-docs --force
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site-dev
+          destination_dir: dev-docs
+          keep_files: true


### PR DESCRIPTION
mkdocs gh-deploy has no --dest-dir option, and it replaces the entire gh-pages branch (wiping mike-managed user docs). Switch to building with mkdocs build then deploying with peaceiris/actions-gh-pages, which supports destination_dir and keep_files to update only dev-docs/ without touching the rest of the branch.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
