### PR TITLE
ci(release): use RELEASE_TOKEN to bypass branch protection on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.14'
@@ -28,7 +28,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v9
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_TOKEN }}
           push: "true"
           changelog: "true"
           vcs_release: "false"


### PR DESCRIPTION
GITHUB_TOKEN cannot push to main when branch protection requires PRs. RELEASE_TOKEN is a fine-grained PAT scoped to this repo with contents read/write, owned by an org admin who has bypass rights.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
