### PR TITLE
build(release): add [skip ci] to PSR release commit message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,3 +111,4 @@ version_variables = []
 version_toml = []
 major_on_zero = false
 changelog_file = "CHANGELOG.md"
+commit_message = "chore(release): v{version} [skip ci]"


### PR DESCRIPTION
PSR pushes a version bump commit to main using the GitHub App token, which triggers the release workflow again. Since the App token is not subject to GitHub's re-trigger suppression (unlike GITHUB_TOKEN), the second run would be a no-op but wastes CI minutes. Adding [skip ci] prevents the re-trigger. The docs site still updates via the release: published trigger that fires moments later.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
