### PR TITLE
fix(docs): fix empty changelog page

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,4 @@
-# Changelog
-
+<!-- markdownlint-disable-file MD041 -->
 {%
   include-markdown "../CHANGELOG.md"
-  start="<!-- version list -->"
 %}


### PR DESCRIPTION
PSR replaced CHANGELOG.md entirely, removing the <!-- version list --> marker that docs/changelog.md used as a start anchor. Without the marker include-markdown included nothing. Remove the start filter to include the full file, and suppress MD041 since the linter cannot see past the include directive to the # CHANGELOG heading PSR generates.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
