### PR TITLE
fix(mkdocs): add pymdownx.superfences to fix code blocks inside tabs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,5 +96,6 @@ extra:
     provider: mike
 
 markdown_extensions:
+  - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true


### PR DESCRIPTION
Without superfences, fenced code blocks inside content tabs render as literal text with the ``` markers visible instead of as code blocks.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
