### PR TITLE
docs(language-guide): fix __run__ → _run in overview examples [skip ci]

### DIFF
--- a/docs/language-guide/index.md
+++ b/docs/language-guide/index.md
@@ -21,7 +21,7 @@ a language's tokens, syntax, and semantics.
 
     Exp
     %%%
-    def __run__(self):
+    def _run(self):
         print("Hello")
     %%%
     ```
@@ -44,7 +44,7 @@ a language's tokens, syntax, and semantics.
 
     Exp
     %%%
-    public void __run__() {
+    public void _run() {
         System.out.println("Hello");
     }
     %%%


### PR DESCRIPTION
Corrects the Python and Java semantic section examples to use the actual entry point name _run (single underscore) instead of __run__ (double).


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
