### PR TITLE
feat(java): add class fragment support to Java emitter

### DIFF
--- a/src/plcc/lang/ext/java/emit.py
+++ b/src/plcc/lang/ext/java/emit.py
@@ -72,6 +72,7 @@ def main(argv=None):
         content = class_template.render(
             cls=cls,
             import_fragments=[f for f in frags if f['kind'] == 'import'],
+            class_fragments=[f for f in frags if f['kind'] == 'class'],
             init_fragments=[f for f in frags if f['kind'] == 'init'],
             body_fragments=[f for f in frags if f['kind'] == 'body'],
         )

--- a/src/plcc/lang/ext/java/emit_test.py
+++ b/src/plcc/lang/ext/java/emit_test.py
@@ -231,6 +231,30 @@ def test_verbose_flag_accepted(tmp_path, monkeypatch):
     run_main([f'--output={tmp_path}', '-v'])
 
 
+def test_class_fragment_appears_on_class_declaration_line(tmp_path, monkeypatch):
+    model = _trivial_model()
+    model['semantic_sections'][0]['fragments'].append(
+        {"class_name": "Program", "kind": "class", "body": "implements Runnable"}
+    )
+    monkeypatch.setattr('sys.stdin', io.StringIO(json.dumps(model)))
+    run_main([f'--output={tmp_path}'])
+    program_java = (tmp_path / 'Program.java').read_text()
+    class_decl_line = next(l for l in program_java.splitlines() if 'class Program' in l)
+    assert 'implements Runnable' in class_decl_line
+
+
+def test_class_fragment_appears_on_abstract_class_declaration_line(tmp_path, monkeypatch):
+    model = _trivial_model()
+    model['semantic_sections'][0]['fragments'].append(
+        {"class_name": "Expr", "kind": "class", "body": "implements Cloneable"}
+    )
+    monkeypatch.setattr('sys.stdin', io.StringIO(json.dumps(model)))
+    run_main([f'--output={tmp_path}'])
+    expr_java = (tmp_path / 'Expr.java').read_text()
+    class_decl_line = next(l for l in expr_java.splitlines() if 'class Expr' in l)
+    assert 'implements Cloneable' in class_decl_line
+
+
 def test_body_fragment_pasted_into_class_when_language_is_lowercase(tmp_path, monkeypatch):
     model = _trivial_model()
     model['semantic_sections'][0]['language'] = 'java'

--- a/src/plcc/lang/ext/java/templates/class_file.java.jinja
+++ b/src/plcc/lang/ext/java/templates/class_file.java.jinja
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 import runtime.Token;
 
-public {% if cls.abstract %}abstract {% endif %}class {{ cls.name }}{% if cls.extends %} extends {{ cls.extends }}{% else %} extends runtime.Node{% endif %} {
+public {% if cls.abstract %}abstract {% endif %}class {{ cls.name }}{% if cls.extends %} extends {{ cls.extends }}{% else %} extends runtime.Node{% endif %}{% for frag in class_fragments %} {{ frag.body }}{% endfor %} {
 {% if not cls.abstract %}
 
     public static final String _RULE_NAME = {{ cls.rule_name | tojson }};


### PR DESCRIPTION
Pass class_fragments to the template and render them on the class declaration line after the extends clause, matching the original PLCC's /*Cls:class*/ hook behavior.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
