### PR TITLE
fix(haskell): unskip Token runtime tests and add missing bytestring dep

### DIFF
--- a/src/plcc/lang/ext/haskell/runtime/token_test.py
+++ b/src/plcc/lang/ext/haskell/runtime/token_test.py
@@ -18,7 +18,7 @@ def _build_and_run(tmp_path, main_hs):
         executable     test-token
           main-is:          Main.hs
           other-modules:    Token
-          build-depends:    base, aeson, text
+          build-depends:    base, aeson, bytestring, text
           default-language: Haskell2010
           hs-source-dirs:   .
     """))
@@ -30,7 +30,6 @@ def _build_and_run(tmp_path, main_hs):
     return result.stdout.strip()
 
 
-@pytest.mark.skip(reason="requires cabal, run after devcontainer rebuild")
 def test_token_parses_kind_and_lexeme(tmp_path):
     output = _build_and_run(tmp_path, textwrap.dedent("""\
         module Main where
@@ -47,7 +46,6 @@ def test_token_parses_kind_and_lexeme(tmp_path):
     assert output == "INT\n42"
 
 
-@pytest.mark.skip(reason="requires cabal, run after devcontainer rebuild")
 def test_token_show(tmp_path):
     output = _build_and_run(tmp_path, textwrap.dedent("""\
         module Main where

--- a/src/plcc/lang/ext/haskell/runtime/token_test.py
+++ b/src/plcc/lang/ext/haskell/runtime/token_test.py
@@ -1,3 +1,4 @@
+import shutil
 import subprocess
 import textwrap
 from pathlib import Path
@@ -5,6 +6,19 @@ from pathlib import Path
 import pytest
 
 TOKEN_HS = Path(__file__).parent / 'Token.hs'
+
+def _hackage_available():
+    if not shutil.which('cabal'):
+        return False
+    for base in [Path.home() / '.cabal', Path.home() / '.local' / 'state' / 'cabal']:
+        if (base / 'packages' / 'hackage.haskell.org').exists():
+            return True
+    return False
+
+_skip_no_hackage = pytest.mark.skipif(
+    not _hackage_available(),
+    reason="requires cabal with hackage package list (run 'cabal update')",
+)
 
 
 def _build_and_run(tmp_path, main_hs):
@@ -30,6 +44,7 @@ def _build_and_run(tmp_path, main_hs):
     return result.stdout.strip()
 
 
+@_skip_no_hackage
 def test_token_parses_kind_and_lexeme(tmp_path):
     output = _build_and_run(tmp_path, textwrap.dedent("""\
         module Main where
@@ -46,6 +61,7 @@ def test_token_parses_kind_and_lexeme(tmp_path):
     assert output == "INT\n42"
 
 
+@_skip_no_hackage
 def test_token_show(tmp_path):
     output = _build_and_run(tmp_path, textwrap.dedent("""\
         module Main where


### PR DESCRIPTION
The two cabal-based tests were unconditionally skipped despite cabal being available. The build also failed because the cabal template was missing bytestring in build-depends (needed for Data.ByteString.Lazy.Char8).


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
