### PR TITLE
docs: reorganize BNF tables to 4-column format with LHS/RHS clarity

### DIFF
--- a/docs/language-guide/languages/java.md
+++ b/docs/language-guide/languages/java.md
@@ -68,17 +68,16 @@ Running this with `echo "1 + 2" | plcc-rep` prints `3`.
 
 ## BNF to Java constructs
 
-| Grammar construct | Java | Example from spec |
-| --- | --- | --- |
-| Concrete non-terminal rule | Java class with public fields and constructor | `<Exp:NumExp> ::= <NUM>` |
-| Abstract non-terminal (has alternatives) | `abstract` Java class | `<Exp>` |
-| Named non-terminal field (`:name` on RHS) | `name` — instance of that class | `<Exp:left>` → `left` |
-| Captured terminal (`<TOKEN>`) | `name` — a `Token` | `<NUM>` → `num` |
-| Token string value | `.lexeme` on the token | `num.lexeme` → `"42"` |
-| Uncaptured terminal (no angle brackets) | Not stored, no field | `PLUS` in `<Exp:AddExp>` |
-| Arbno (`**=`) | `ArrayList<ClassName> nameList` | `<Prog> **= <Exp>` → `expList` |
+| Grammar Construct | Example from spec | Java Construct | Example based on spec |
+| --- | --- | --- | --- |
+| Concrete rule (LHS, no alt name) — generates one class | `<Prog>` in `<Prog> **= <Exp>` | Java class with public fields and constructor | `class Prog extends _Start { public ArrayList<Exp> expList; ... }` |
+| Alternative rule (LHS, with alt name) — base nonterminal becomes abstract | `<Exp:AddExp>` in `<Exp:AddExp> ::= ...` | Java class extending the base nonterminal | `class AddExp extends Exp { public Exp left, right; ... }` |
+| Named non-terminal (RHS) | `<Exp:left>` | `left` — an `Exp` instance | `left.eval()` |
+| Captured terminal (RHS) | `<NUM>` | `num` — a `Token`; `.lexeme` for the string value | `Integer.parseInt(num.lexeme)` |
+| Uncaptured terminal (RHS) | `PLUS` | No field generated | — |
+| Arbno rule (`**=`) | `<Prog> **= <Exp>` | `expList` — `ArrayList<Exp>` | `for (Exp exp : expList)` |
 
-Without explicit `:name` on a RHS symbol, the field name is the symbol name lowercased. Use explicit names when two RHS symbols would produce the same field name.
+Without explicit `:name` on a RHS symbol, the field name is the symbol name lowercased (e.g., `<Exp>` → `exp`, `<NUM>` → `num`). Use explicit names when two RHS symbols would produce the same field name.
 
 All generated classes are in the same package, so sibling classes are accessible without explicit imports.
 

--- a/docs/language-guide/languages/javascript.md
+++ b/docs/language-guide/languages/javascript.md
@@ -60,17 +60,16 @@ Running this with `echo "1 + 2" | plcc-rep` prints `3`.
 
 ## BNF to JavaScript constructs
 
-| Grammar construct | JavaScript | Example from spec |
-| --- | --- | --- |
-| Concrete non-terminal rule | ES6 class with constructor and fields | `<Exp:NumExp> ::= <NUM>` |
-| Abstract non-terminal (has alternatives) | ES6 class, no constructor | `<Exp>` |
-| Named non-terminal field (`:name` on RHS) | `this.name` — instance of that class | `<Exp:left>` → `this.left` |
-| Captured terminal (`<TOKEN>`) | `this.name` — a `Token` | `<NUM>` → `this.num` |
-| Token string value | `.lexeme` on the token | `this.num.lexeme` → `"42"` |
-| Uncaptured terminal (no angle brackets) | Not stored, no field | `PLUS` in `<Exp:AddExp>` |
-| Arbno (`**=`) | Array field named `<symbol>List` | `<Prog> **= <Exp>` → `this.expList` |
+| Grammar Construct | Example from spec | JavaScript Construct | Example based on spec |
+| --- | --- | --- | --- |
+| Concrete rule (LHS, no alt name) — generates one class | `<Prog>` in `<Prog> **= <Exp>` | ES6 class with constructor and fields | `class Prog extends _Start { constructor(expList) { ... } }` |
+| Alternative rule (LHS, with alt name) — base nonterminal becomes abstract | `<Exp:AddExp>` in `<Exp:AddExp> ::= ...` | ES6 class extending the base nonterminal | `class AddExp extends Exp { constructor(left, right) { ... } }` |
+| Named non-terminal (RHS) | `<Exp:left>` | `this.left` — an `Exp` instance | `this.left.eval()` |
+| Captured terminal (RHS) | `<NUM>` | `this.num` — a `Token`; `.lexeme` for the string value | `parseInt(this.num.lexeme)` |
+| Uncaptured terminal (RHS) | `PLUS` | No field generated | — |
+| Arbno rule (`**=`) | `<Prog> **= <Exp>` | `this.expList` — `Array` of `Exp` | `this.expList.map(e => e.eval())` |
 
-Without explicit `:name` on a RHS symbol, the field name is the symbol name lowercased (e.g., `<Exp>` → `exp`, `<NUM>` → `num`). Use explicit names when two RHS symbols would produce the same field name.
+Without explicit `:name` on a RHS symbol, the field name is the symbol name lowercased (e.g., `<Exp>` → `this.exp`, `<NUM>` → `this.num`). Use explicit names when two RHS symbols would produce the same field name.
 
 ## Fragment kinds
 

--- a/docs/language-guide/languages/python.md
+++ b/docs/language-guide/languages/python.md
@@ -57,17 +57,16 @@ Running this with `echo "1 + 2" | plcc-rep` prints `3`.
 
 ## BNF to Python constructs
 
-| Grammar construct | Python | Example from spec |
-| --- | --- | --- |
-| Concrete non-terminal rule | Python dataclass with fields | `<Exp:NumExp> ::= <NUM>` |
-| Abstract non-terminal (has alternatives) | Python class, no fields or constructor | `<Exp>` |
-| Named non-terminal field (`:name` on RHS) | `self.name` — instance of that class | `<Exp:left>` → `self.left` |
-| Captured terminal (`<TOKEN>`) | `self.name` — a `Token` | `<NUM>` → `self.num` |
-| Token string value | `.lexeme` on the token | `self.num.lexeme` → `"42"` |
-| Uncaptured terminal (no angle brackets) | Not stored, no field | `PLUS` in `<Exp:AddExp>` |
-| Arbno (`**=`) | `List[ClassName] nameList` | `<Prog> **= <Exp>` → `self.expList` |
+| Grammar Construct | Example from spec | Python Construct | Example based on spec |
+| --- | --- | --- | --- |
+| Concrete rule (LHS, no alt name) — generates one class | `<Prog>` in `<Prog> **= <Exp>` | Python dataclass with fields | `@dataclass class Prog(_Start): expList: List[Exp]` |
+| Alternative rule (LHS, with alt name) — base nonterminal becomes abstract | `<Exp:AddExp>` in `<Exp:AddExp> ::= ...` | Python dataclass extending the base nonterminal | `@dataclass class AddExp(Exp): left: Exp; right: Exp` |
+| Named non-terminal (RHS) | `<Exp:left>` | `self.left` — an `Exp` instance | `self.left.eval()` |
+| Captured terminal (RHS) | `<NUM>` | `self.num` — a `Token`; `.lexeme` for the string value | `int(self.num.lexeme)` |
+| Uncaptured terminal (RHS) | `PLUS` | No field generated | — |
+| Arbno rule (`**=`) | `<Prog> **= <Exp>` | `self.expList` — `List[Exp]` | `[e.eval() for e in self.expList]` |
 
-Without explicit `:name` on a RHS symbol, the field name is the symbol name lowercased. Use explicit names when two RHS symbols would produce the same field name.
+Without explicit `:name` on a RHS symbol, the field name is the symbol name lowercased (e.g., `<Exp>` → `self.exp`, `<NUM>` → `self.num`). Use explicit names when two RHS symbols would produce the same field name.
 
 ## Fragment kinds
 


### PR DESCRIPTION
Fixes the concrete/abstract distinction: a rule with no alt name on the LHS is a concrete rule; a rule with an alt name (e.g. <Exp:AddExp>) is an alternative rule that makes the base nonterminal abstract. Removes the separate "Token string value" row by folding .lexeme into the captured terminal row. Adds an "Example based on spec" column (generated or semantic code snippet) alongside the renamed "Example from spec" column.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
