### PR TITLE
fix: prevent RecursionError in build_follow_sets on left-recursive gr…

### DIFF
--- a/src/plcc/spec/syntax/validations/ll1/build_follow_sets.py
+++ b/src/plcc/spec/syntax/validations/ll1/build_follow_sets.py
@@ -66,14 +66,18 @@ class FollowSetBuilder:
             self._changed = True
 
     def _canDeriveEmpty(self, symbols):
-        return all(self._canDeriveEmptyString(symbol) for symbol in symbols)
+        return all(self._canDeriveEmptyString(symbol, set()) for symbol in symbols)
 
-    def _canDeriveEmptyString(self, symbol):
+    def _canDeriveEmptyString(self, symbol, computing):
+        if symbol in computing:
+            return False
         if self.grammar.isNonterminal(symbol):
-            if self._allRulesCanDeriveEmpty(symbol):
-                return True
+            computing.add(symbol)
+            result = self._allRulesCanDeriveEmpty(symbol, computing)
+            computing.discard(symbol)
+            return result
         return False
 
-    def _allRulesCanDeriveEmpty(self, symbol):
-        if all(self._canDeriveEmptyString(rule) for rule in self.grammar.getForms(symbol)[0]):
+    def _allRulesCanDeriveEmpty(self, symbol, computing):
+        if all(self._canDeriveEmptyString(rule, computing) for rule in self.grammar.getForms(symbol)[0]):
             return True

--- a/src/plcc/spec/syntax/validations/ll1/build_follow_sets_test.py
+++ b/src/plcc/spec/syntax/validations/ll1/build_follow_sets_test.py
@@ -97,6 +97,22 @@ def test__follow_set_with_terminal_after_captured_rule():
     assert follows["d"] == {"A", "C"}
 
 
+def test_left_recursive_nonterminal_inside_nullable_does_not_crash():
+    """
+    build_follow_sets should not raise RecursionError when a nullable
+    nonterminal's first production expands into a left-recursive one.
+    Reproduces the crash from: prog **= exp  with  exp ::= exp PLUS exp | NUM.
+    """
+    grammar, firsts, follows = setup([
+        'prog explist',
+        'explist exp explist',
+        'explist',
+        'exp exp PLUS exp',
+        'exp NUM',
+    ])
+    assert follows is not None
+
+
 def setup(lines):
     g = Grammar()
     for line in [line.split() for line in lines]:


### PR DESCRIPTION
…ammars

_canDeriveEmptyString had no cycle detection, so checking if a nullable nonterminal could derive ε would recurse infinitely when its first production expanded into a left-recursive nonterminal (e.g., prog **= exp with exp ::= exp PLUS exp). Thread a `computing` set through to break cycles.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
