### PR TITLE
fix: guard against None separator in _validateSeparatorIsTerminal

### DIFF
--- a/src/plcc/spec/syntax/validations/validate_rhs.py
+++ b/src/plcc/spec/syntax/validations/validate_rhs.py
@@ -78,6 +78,8 @@ class SyntacticRhsValidator:
                     seen.add(symbolName)
 
     def _validateSeparatorIsTerminal(self, rule):
+        if rule.separator is None:
+            return
         if not re.match(r"^[A-Z][A-Z0-9_]+$", rule.separator.name):
             self._appendInvalidRhsSeparatorTypeError(rule)
 

--- a/src/plcc/spec/syntax/validations/validate_rhs_test.py
+++ b/src/plcc/spec/syntax/validations/validate_rhs_test.py
@@ -108,6 +108,10 @@ def test_valid_rhs_alt_name():
 <Sentence> ::= <Word:name>''')
 
 
+def test_repeating_rule_without_separator_is_valid():
+    assertValid('''<Sentence> **= WORD''')
+
+
 def test_valid_separator_terminal():
     assertValid('''<Sentence> **= WORD +PERIOD''')
 


### PR DESCRIPTION
A repeating rule using **= without a separator has rule.separator=None, causing an AttributeError when the validator tried to access .name.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
