### PR TITLE
fix: replace 'eof' with 'end of file' in parser error messages

### DIFF
--- a/src/plcc/parser/predictive_parser.py
+++ b/src/plcc/parser/predictive_parser.py
@@ -111,11 +111,14 @@ def parse(ll1: dict, tokens: list, tracer=None) -> tuple:
         cursor[0] += 1
         return tok
 
+    def _display_name(token_name):
+        return "end of file" if token_name == "eof" else repr(token_name)
+
     def expect(sym):
         tok = current()
         if tok["name"] != sym:
             raise ParseError(
-                f"expected {sym!r}, got {tok['name']!r}",
+                f"expected {sym!r}, got {_display_name(tok['name'])}",
                 source=tok["source"],
                 found=tok["name"],
             )
@@ -143,7 +146,7 @@ def parse(ll1: dict, tokens: list, tracer=None) -> tuple:
         production = nt_table.get(lookahead)
         if production is None:
             raise ParseError(
-                f"unexpected {lookahead!r}, no production for {sym!r}",
+                f"unexpected {_display_name(lookahead)}, no production for {sym!r}",
                 source=current()["source"],
                 found=lookahead,
             )

--- a/src/plcc/parser/predictive_parser_test.py
+++ b/src/plcc/parser/predictive_parser_test.py
@@ -174,6 +174,20 @@ def test_nested_nonterminal_child_is_tree():
 
 # --- error cases ---
 
+def test_no_production_for_eof_message_says_end_of_file():
+    with pytest.raises(ParseError) as exc_info:
+        parse(_TRIVIAL_LL1, [])
+    assert "end of file" in exc_info.value.args[0]
+    assert "'eof'" not in exc_info.value.args[0]
+
+
+def test_expected_terminal_got_eof_message_says_end_of_file():
+    with pytest.raises(ParseError) as exc_info:
+        parse(_ADDITION_LL1, [_tok("NUM", "1")])
+    assert "end of file" in exc_info.value.args[0]
+    assert "'eof'" not in exc_info.value.args[0]
+
+
 def test_wrong_terminal_raises_parse_error():
     with pytest.raises(ParseError):
         parse(_TRIVIAL_LL1, [_tok("IDENTIFIER", "x")])


### PR DESCRIPTION
Closes #120.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
