### PR TITLE
fix(docs): only deploy developer docs on push events

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,9 +48,14 @@ jobs:
           MAJOR_MINOR=$(echo "${VERSION#v}" | cut -d. -f1,2)
           pdm run mike deploy --update-aliases "${MAJOR_MINOR}" latest
           pdm run mike set-default latest
+      # Developer docs track main, not releases. Release events check out
+      # the tag, which can lag main; rebuilding dev-docs from it would
+      # clobber newer content deployed by the push-triggered run.
       - name: Build developer docs
+        if: github.event_name == 'push'
         run: pdm run mkdocs build --config-file mkdocs-dev.yml
       - name: Merge developer docs into gh-pages
+        if: github.event_name == 'push'
         run: |
           git checkout gh-pages
           rsync -a --delete site-dev/ dev-docs/


### PR DESCRIPTION
Release-triggered docs runs check out the release tag, which can lag main's tip when commits land between tagging and the release event. Rebuilding dev-docs from the tag then clobbers newer content the push-triggered run already deployed — observed live when the v0.64.2 release run deleted the just-deployed issue-140 page. Developer docs track main, so build and merge them only on push; release runs still deploy the versioned user docs and push mike's commits.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
