### PR TITLE
docs: remove empty instructor guide before v1.0.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,6 @@ using dedicated command-line tools.
 - [Quick Start](quick-start.md) — Install plcc-ng and run your first specification in under 10 minutes.
 - [Language Guide](language-guide/index.md) — Token rules, BNF syntax, code generation, worked examples.
 - [CLI Reference](cli/index.md) — Every command, every flag.
-- [Instructor Guide](instructor-guide/index.md) — What students need to know, what they can learn, what materials and support exist.
 
 ## Join Our Community
 

--- a/docs/instructor-guide/adopting.md
+++ b/docs/instructor-guide/adopting.md
@@ -1,3 +1,0 @@
-# Adopting plcc-ng
-
-*Content coming soon.*

--- a/docs/instructor-guide/evaluating.md
+++ b/docs/instructor-guide/evaluating.md
@@ -1,3 +1,0 @@
-# Evaluating plcc-ng
-
-*Content coming soon.*

--- a/docs/instructor-guide/index.md
+++ b/docs/instructor-guide/index.md
@@ -1,3 +1,0 @@
-# Instructor Guide
-
-*Content coming soon.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,10 +96,6 @@ nav:
       - plcc-tokens: cli/commands/plcc-tokens.md
       - plcc-trees: cli/commands/plcc-trees.md
       - plcc-version: cli/commands/plcc-version.md
-  - Instructor Guide:
-    - Overview: instructor-guide/index.md
-    - Evaluating plcc-ng: instructor-guide/evaluating.md
-    - Adopting plcc-ng: instructor-guide/adopting.md
   - Acknowledgments: acknowledgments.md
 
 extra:


### PR DESCRIPTION
The instructor guide pages were stubs with no content. Rather than ship placeholder pages, remove the section from the nav and site until there is real content to publish.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
