### PR TITLE
test(cache): fold content into test-cache key (issue 152)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ All operational commands live in [bin/](bin/). **Before writing a new script, ch
 
 ### Test output cache
 
-All test scripts cache their output to `/tmp` so agents and tools can grep results without re-running the suite. The cache is keyed on git state (`git status --porcelain` + `git rev-parse HEAD`) and is invalidated automatically whenever the working tree or HEAD changes.
+All test scripts cache their output to `/tmp` so agents and tools can grep results without re-running the suite. The cache is keyed on git state (`git rev-parse HEAD` + `git status --porcelain` + `git diff HEAD` + the contents of untracked files) and is invalidated automatically whenever the working tree, HEAD, or any file's content changes.
 
 | Command | What it does |
 |---|---|

--- a/bin/test/_cache.bash
+++ b/bin/test/_cache.bash
@@ -10,10 +10,14 @@ _cache_log_event() {
 }
 
 _cache_key() {
-    local head status
+    local head status diff untracked
     head=$(git rev-parse HEAD 2>/dev/null) || return 1
     status=$(git status --porcelain 2>/dev/null) || return 1
-    printf '%s\n%s' "${head}" "${status}" | sha256sum | cut -d' ' -f1
+    diff=$(git diff HEAD 2>/dev/null) || return 1
+    untracked=$(git ls-files --others --exclude-standard -z 2>/dev/null \
+        | xargs -0 -I{} cat "{}" 2>/dev/null) || return 1
+    printf '%s\n%s\n%s\n%s' "${head}" "${status}" "${diff}" "${untracked}" \
+        | sha256sum | cut -d' ' -f1
 }
 
 run_cached() {

--- a/tests/bats/commands/cache.bats
+++ b/tests/bats/commands/cache.bats
@@ -98,6 +98,16 @@ teardown() {
     [[ "$output" == *"[cache skip] units"* ]]
 }
 
+@test "content change on already-dirty file invalidates cache" {
+    local dirty_file="${PROJECT_ROOT}/tmp_test_dirty_$$.txt"
+    echo "version1" > "${dirty_file}"
+    bash -c "source '${CACHE_HELPER}' && run_cached '${CACHE_FILE}' echo first-run 2>/dev/null" || true
+    echo "version2" > "${dirty_file}"
+    run bash -c "source '${CACHE_HELPER}' && run_cached '${CACHE_FILE}' echo second-run 2>/dev/null"
+    rm -f "${dirty_file}"
+    [[ "$output" == "second-run" ]]
+}
+
 @test "fallback: runs uncached when git is unavailable" {
     local fake_bin
     fake_bin=$(mktemp -d)

--- a/tests/bats/commands/cache.bats
+++ b/tests/bats/commands/cache.bats
@@ -9,11 +9,13 @@ setup() {
     CACHE_DIR="$(mktemp -d)"
     CACHE_FILE="${CACHE_DIR}/plcc-test-units.log"
     export PLCC_TEST_STATS_LOG="${CACHE_DIR}/stats.log"
+    DIRTY_FILE="${PROJECT_ROOT}/tmp_test_dirty_$$.txt"
     unset PLCC_NO_TEST_CACHE
 }
 
 teardown() {
     rm -rf "${CACHE_DIR}"
+    rm -f "${DIRTY_FILE}"
 }
 
 @test "cache miss: runs command and creates cache and meta files" {
@@ -99,12 +101,10 @@ teardown() {
 }
 
 @test "content change on already-dirty file invalidates cache" {
-    local dirty_file="${PROJECT_ROOT}/tmp_test_dirty_$$.txt"
-    echo "version1" > "${dirty_file}"
+    echo "version1" > "${DIRTY_FILE}"
     bash -c "source '${CACHE_HELPER}' && run_cached '${CACHE_FILE}' echo first-run 2>/dev/null" || true
-    echo "version2" > "${dirty_file}"
+    echo "version2" > "${DIRTY_FILE}"
     run bash -c "source '${CACHE_HELPER}' && run_cached '${CACHE_FILE}' echo second-run 2>/dev/null"
-    rm -f "${dirty_file}"
     [[ "$output" == "second-run" ]]
 }
 


### PR DESCRIPTION
Editing an already-dirty file didn't change git status --porcelain's output, so the cache key stayed the same and a stale, pre-edit result was replayed as fresh. Fold `git diff HEAD` and untracked file contents into the key so any content change always misses.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.
