### PR TITLE
docs(roadmap): retire Dev-docs cleanup milestone

### DIFF
--- a/dev-docs/roadmap.md
+++ b/dev-docs/roadmap.md
@@ -1,21 +1,5 @@
 # Roadmap
 
-## Dev-docs cleanup
-
-Resolved #145 (mkdocs `--strict` warnings) by deciding to decommission
-the dev-docs site rather than work around `docs_dir`'s constraints, and
-split the remaining work into these issues. Order: decommission first
-since it's the largest scope cut and removes the premise that a strict
-build must stay green; the rest are independent content/tooling
-hygiene with no urgency relative to each other. Completed items are
-checked off (and stay listed) so this section tracks progress; it
-retires once every item below is checked off.
-
-1. [x] [#148](issues/done/148-decommission-dev-docs-mkdocs-site.md) — remove the mkdocs-dev.yml build/deploy and its published gh-pages content; ~70% of #145's warnings exist only because of this build.
-2. [x] [#149](issues/done/149-fix-stale-issues-done-links.md) — fix broken issues/NNN links that should point to issues/done/; independent of #148, real breakage on GitHub either way.
-3. [x] [#150](issues/done/150-close-script-auto-fix-links.md) — harden close.bash to prevent #149's bug class from recurring.
-4. [x] [#151](issues/done/151-migrate-superpowers-docs-to-dev-docs.md) — migrate docs/superpowers/specs/ and docs/superpowers/plans/ into dev-docs/; discovered while working #150, same content/tooling hygiene as the rest of this cleanup.
-
 ## Open Issues
 
 ### Test


### PR DESCRIPTION
All four issues in the section are closed; per issue-conventions.md a milestone section retires once every item is checked off.


The authors of this PR...

- [x] Sign off on the [DCO](https://developercertificate.org/).
- [x] License their changes under the project's license.